### PR TITLE
Remove string types that are deprecated in 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5.0-
 NullableArrays
 JLD

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -44,7 +44,7 @@ elements.
 Pool{S, T <: Unsigned, ID}()
 Pool{S, T <: Unsigned}(index::Vector{S}, invindex::Dict{S,T})
 Pool{T <: Unsigned, S}(::Type{T}, ::Type{S})
-Pool(t::Type = UInt, s::Type = UTF8String)
+Pool(t::Type = UInt, s::Type = String)
 Pool(t::Type = UInt, X)
 ```
 
@@ -83,8 +83,8 @@ Pool(t::Type = UInt, X)
 
 ```julia
 p = Pool(UInt8, Float64)  # A Float64 pool with UInt8 references
-p = Pool()  # The default pool, a UTF8String pool with UInt references
-p = Pool(UInt8, ["x", "y", "z"])  # An ASCIIString pool with UInt8 references
+p = Pool()  # The default pool, a String pool with UInt references
+p = Pool(UInt8, ["x", "y", "z"])  # An String pool with UInt8 references
 get!(p, "a")  # 4
 get!(p, "y")  # 2
 length(p)  # 4
@@ -110,7 +110,7 @@ function Pool{T <: Unsigned, S}(::Type{T}, ::Type{S})
     Pool{S,T,object_id(d)}(T[], d)
 end
 
-Pool(t::Type = UInt, s::Type = UTF8String) = Pool(t, s)
+Pool(t::Type = UInt, s::Type = String) = Pool(t, s)
 
 function Pool(t::Type, X)
     p = Pool(t, eltype(X))

--- a/src/pooledstring.jl
+++ b/src/pooledstring.jl
@@ -164,9 +164,9 @@ end
 pstring{S <: AbstractString}(s::S) = pstring(__GLOBAL_POOL__, String(s))
 
 pstring{S <: AbstractString}(pool::AbstractPool{S}, s...) = 
-    pstring(pool, String(string(s...)))
+    pstring(pool, string(s...))
     
-pstring(s...) = pstring(__GLOBAL_POOL__, String(string(s...)))
+pstring(s...) = pstring(__GLOBAL_POOL__, string(s...))
 
 
 ##############################################################################

--- a/src/pooledstring.jl
+++ b/src/pooledstring.jl
@@ -72,24 +72,24 @@ levels(p)
 
 ### Notes
 
-With promotion and conversion, PooledString's are converted to UTF8String's. 
+With promotion and conversion, PooledString's are converted to String's. 
 This happens when PooledString's are combined with other string types and with
 PooledString's using a different pool. Here are some examples:
 
 ```julia
 [pstring("hi"), pstring("bye")]          #  => Vector{Pooled String} 
-[pstring("hi"), "bye"]                   #  => Vector{UTF8String} 
-[pstring("hi"), pstring(Pool(), "bye")]  #  => Vector{UTF8String} 
+[pstring("hi"), "bye"]                   #  => Vector{String} 
+[pstring("hi"), pstring(Pool(), "bye")]  #  => Vector{String} 
 pstring("hi") == pstring(Pool(), "hi")   #  => true
 pstring("hi") == "hi"                    #  => true
 pstring("a") < "b"                       #  => true
 ```
 
 Missing values are also important to consider with promotion and conversion.
-`PooledString()` is a null PooledString. When promoted to UTF8String, it becomes
+`PooledString()` is a null PooledString. When promoted to String, it becomes
 "__NULL__". That is important for comparisons. Also, null PooledStrings are 
 treated as equal during comparisons, even if the pools are different. The 
-UTF8String value of a null PooledString is chosen with a leading UTF-8 character
+String value of a null PooledString is chosen with a leading UTF-8 character
 to make it sort to the end. For specific treatment of missing values, use
 `isnull` to check for missing values.
 
@@ -101,7 +101,7 @@ PooledString() == "__NULL__"              #  => true - DON'T USE - use `isnul
 sort([PooledString(), pstring("z"), pstring("a")])
      #  =>   Vector{PooledString}: ["a", "z", #NULL]
 sort([PooledString(), "z", "a"])
-     #  =>   Vector{UTF8String}: ["a", "z", "__NULL__"]
+     #  =>   Vector{String}: ["a", "z", "__NULL__"]
 ```
 
 """
@@ -161,12 +161,12 @@ function pstring{S <: AbstractString, T <: Unsigned}(pool::AbstractPool{S,T}, s:
     PooledString(i, pool)
 end
 
-pstring{S <: AbstractString}(s::S) = pstring(__GLOBAL_POOL__, utf8(s))
+pstring{S <: AbstractString}(s::S) = pstring(__GLOBAL_POOL__, String(s))
 
 pstring{S <: AbstractString}(pool::AbstractPool{S}, s...) = 
-    pstring(pool, utf8(string(s...)))
+    pstring(pool, String(string(s...)))
     
-pstring(s...) = pstring(__GLOBAL_POOL__, utf8(string(s...)))
+pstring(s...) = pstring(__GLOBAL_POOL__, String(string(s...)))
 
 
 ##############################################################################

--- a/test/pool.jl
+++ b/test/pool.jl
@@ -17,9 +17,9 @@ a = Pool(UInt[], Dict{UInt,UInt}())
 @test isa(a, Pool{UInt,UInt})
 
 a = Pool()
-@test isa(a, Pool{UTF8String,UInt64})
+@test isa(a, Pool{String,UInt64})
 a = Pool(UInt8)
-@test isa(a, Pool{UTF8String,UInt8})
+@test isa(a, Pool{String,UInt8})
 a = Pool(UInt8, Float64)
 @test isa(a, Pool{Float64,UInt8})
 a = Pool(UInt8, UInt8)
@@ -31,11 +31,11 @@ b = Pool()
 @test a == a
 
 a = Pool(UInt8, ["x", "y", "z"])
-@test isa(a, Pool{ASCIIString,UInt8})
+@test isa(a, Pool{String,UInt8})
 @test levels(a) == ["x", "y", "z"]
 
-a = Pool(UTF8String["x", "y", "z"])
-@test isa(a, Pool{UTF8String,UInt64})
+a = Pool(String["x", "y", "z"])
+@test isa(a, Pool{String,UInt64})
 @test levels(a) == ["x", "y", "z"]
 
 

--- a/test/pooledstring.jl
+++ b/test/pooledstring.jl
@@ -27,15 +27,15 @@ a = PooledString(1, p)
 
 a = pstring()
 @test a == ""
-@test isa(a, PooledString{UTF8String,UInt64})
+@test isa(a, PooledString{String,UInt64})
 
 a = pstring("test")
 @test a == "test"
-@test isa(a, PooledString{UTF8String,UInt64})
+@test isa(a, PooledString{String,UInt64})
 
 a = pstring(Pool(UInt8), 27, "X")
 @test a == "27X"
-@test isa(a, PooledString{UTF8String,UInt8})
+@test isa(a, PooledString{String,UInt8})
 
 a = pstring("test")
 b = pstring(Pool(), "test")
@@ -49,7 +49,7 @@ x = [a, pstring("b")]
 a = pstring("a")
 x = [a; pstring(Pool(), "b")]
 @test !isa(x, Array{typeof(a),1})
-@test isa(x, Array{UTF8String,1})
+@test isa(x, Array{String,1})
 
 a = pstring("x", "y", 2)
 @test a == "xy2"
@@ -64,8 +64,8 @@ a = pstring("x", "y", 2)
 @test pstring("a") < pstring("b")
 @test pstring("a") < "b"
 
-a = convert(ASCIIString, pstring("hello"))
-@test isa(a, ASCIIString)
+a = convert(String, pstring("hello"))
+@test isa(a, String)
 @test a == "hello"
 
 @test endof(pstring("hello")) == endof("hello")
@@ -74,7 +74,7 @@ a = convert(ASCIIString, pstring("hello"))
 
 p = Pool(UInt8, ["x", "y", "z"])
 a = pstring(p, "hello")
-@test isa(a, PooledString{ASCIIString,UInt8})
+@test isa(a, PooledString{String,UInt8})
 @test levels(a) == ["x", "y", "z", "hello"]
 
 

--- a/test/pooledstringarray.jl
+++ b/test/pooledstringarray.jl
@@ -19,40 +19,40 @@ x = PooledStringArray(UInt8[3,1,1,2], p)
 
 x = PooledStringArray(Pool(UInt8))
 @test length(x) == 0
-@test isa(x, PooledStringArray{UTF8String,1,UInt8})
+@test isa(x, PooledStringArray{String,1,UInt8})
 
 x = PooledStringArray(Pool(UInt8), 3)
 @test size(x) == (3,)
-@test isa(x, PooledStringArray{UTF8String,1,UInt8})
+@test isa(x, PooledStringArray{String,1,UInt8})
 
 x = PooledStringArray(Pool(UInt8), 3, 2)
 @test size(x) == (3,2)
-@test isa(x, PooledStringArray{UTF8String,2,UInt8})
+@test isa(x, PooledStringArray{String,2,UInt8})
 
 x = PooledStringArray(3, 2)
 @test size(x) == (3,2)
-@test isa(x, PooledStringArray{UTF8String,2,UInt})
+@test isa(x, PooledStringArray{String,2,UInt})
 
 x = PooledStringArray([pstring("a"), pstring("b")])
 @test size(x) == (2,)
-@test isa(x, PooledStringArray{UTF8String,1,UInt})
+@test isa(x, PooledStringArray{String,1,UInt})
 
-x = PooledStringArray(UTF8String["a", "b"])
+x = PooledStringArray(String["a", "b"])
 @test size(x) == (2,)
-@test isa(x, PooledStringArray{UTF8String,1,UInt})
+@test isa(x, PooledStringArray{String,1,UInt})
 
 x = PooledStringArray(["a", "b"])
 @test size(x) == (2,)
-@test isa(x, PooledStringArray{UTF8String,1,UInt})
+@test isa(x, PooledStringArray{String,1,UInt})
 
 x = PooledStringArray(["a", "b"], [false, true])
 @test size(x) == (2,)
-@test isa(x, PooledStringArray{UTF8String,1,UInt})
+@test isa(x, PooledStringArray{String,1,UInt})
 @test isnull(x, 2)
 
 x = PooledStringArray(UInt8, ["a", "b"], [false, true])
 @test size(x) == (2,)
-@test isa(x, PooledStringArray{ASCIIString,1,UInt8})
+@test isa(x, PooledStringArray{String,1,UInt8})
 @test isnull(x, 2)
 
 ##############################################################################
@@ -100,7 +100,7 @@ z = [x y]
 @test typeof(x) == typeof(z)
 
 a = PooledStringArray(UInt8, ["x", "y", "z"])
-@test isa(a, PooledStringArray{ASCIIString,1,UInt8})
+@test isa(a, PooledStringArray{String,1,UInt8})
 @test levels(a) == ["x", "y", "z"]
 
 ##############################################################################
@@ -116,14 +116,14 @@ z = repool(x, y.pool)
 @test length(x.pool) == 3
 @test length(y.pool) == 4
 @test length(z.pool) == 4
-@test levels(z) == UTF8String["x", "a", "y", "c"]
+@test levels(z) == String["x", "a", "y", "c"]
 
 x = PooledStringArray(Pool(["x", "a"]), ["b", "c", "a"])
 y = repool(x, Pool(UInt8))
 @test x == y
 @test length(y.pool) == 3
 z = repool(y, Pool(sort(levels(y))))
-@test levels(z) == UTF8String["a", "b", "c"]
+@test levels(z) == String["a", "b", "c"]
 
 zz = rename(z, "a" => "apple", "b" => "banana")
 @test levels(z) == ["a", "b", "c"]
@@ -146,90 +146,90 @@ psv = PooledStringArray(v)
 v1 = push!(copy(v), pstring("x"))
 psv1 = push!(copy(psv), "x")
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = copy(v)
 psv1 = copy(psv)
 x = pop!(v1)
 y = pop!(psv1)
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 @test x == y
-@test isa(x, PooledString{UTF8String,UInt})
-@test isa(y, PooledString{UTF8String,UInt})
+@test isa(x, PooledString{String,UInt})
+@test isa(y, PooledString{String,UInt})
 
 v1 = unshift!(copy(v), pstring("x"))
 psv1 = unshift!(copy(psv), "x")
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = unshift!(copy(v), pstring("x"), pstring("y"))
 psv1 = unshift!(copy(psv), "x", "y")
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = copy(v)
 psv1 = copy(psv)
 x = shift!(v1)
 y = shift!(psv1)
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 @test x == y
-@test isa(x, PooledString{UTF8String,UInt})
-@test isa(y, PooledString{UTF8String,UInt})
+@test isa(x, PooledString{String,UInt})
+@test isa(y, PooledString{String,UInt})
 
 # vc = copy(v)
 # psvc = copy(psv)
 # v1 = splice!(vc, 2, pstring("x"))
 # psv1 = splice!(psvc, 2, "x")
 # @test vc == psvc
-# @test isa(psvc, PooledStringArray{UTF8String,1,UInt})
+# @test isa(psvc, PooledStringArray{String,1,UInt})
 
 v1 = deleteat!(copy(v), 2)
 psv1 = deleteat!(copy(psv), 2)
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = deleteat!(copy(v), 2)
 psv1 = deleteat!(copy(psv), 2)
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = resize!(copy(v), 2)
 psv1 = resize!(copy(psv), 2)
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 # v1 = resize!(copy(v), 5)     ## fails because of #undefs
 psv1 = resize!(copy(psv), 5)
 @test length(psv1) == 5
 @test isnull(psv1,5)
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = append!(copy(v), [pstring("a"), pstring("b")])
 psv1 = append!(copy(psv), ["a", "b"])
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = prepend!(copy(v), [pstring("a"), pstring("b")])
 psv1 = prepend!(copy(psv), ["a", "b"])
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = sizehint!(copy(v), 10)
 psv1 = sizehint!(copy(psv), 10)
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = reverse!(copy(v))
 psv1 = reverse!(copy(psv))
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 v1 = reverse!(copy(v), 2, 3)
 psv1 = reverse!(copy(psv), 2, 3)
 @test v1 == psv1
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 
 ##############################################################################
@@ -264,7 +264,7 @@ psv1 = dropnull(psv)
 @test length(psv1) == 2
 @test !anynull(psv1)
 @test !allnull(psv1)
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 psv1 = padnull!(copy(psv), 1, 3)
 @test length(psv1) == 7
@@ -273,7 +273,7 @@ psv1 = padnull!(copy(psv), 1, 3)
 @test !isnull(psv1, 2)
 @test !isnull(psv1, 4)
 @test isnull(psv1, 5)
-@test isa(psv1, PooledStringArray{UTF8String,1,UInt})
+@test isa(psv1, PooledStringArray{String,1,UInt})
 
 
 end # module


### PR DESCRIPTION
I don't expect this to be merged.
since it does not use Compat, and just won't run on anything less that a particular dev version of 0.5
But making this PR so others can find it.
